### PR TITLE
feat: add fragment retry logic to modbus poller

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -16,9 +16,9 @@ class Growatt {
   void HandleCommand(const String& command, const byte* payload,
                      const unsigned int length, JsonDocument& req,
                      JsonDocument& res);
-  bool ReadInputRegisters();
-  bool ReadHoldingRegisters();
-  bool ReadData();
+  bool ReadInputRegisters(uint8_t& offs);
+  bool ReadHoldingRegisters(uint8_t& offs);
+  bool ReadData(uint8_t maxRetries);
   eDevice_t GetWiFiStickType();
   sGrowattModbusReg_t GetInputRegister(uint16_t reg);
   sGrowattModbusReg_t GetHoldingRegister(uint16_t reg);
@@ -41,6 +41,7 @@ class Growatt {
   eDevice_t _eDevice;
   bool _GotData;
   uint32_t _PacketCnt;
+  uint32_t _PacketCntFailed;
   std::map<String, CommandHandlerFunc> handlers;
 
   eDevice_t _InitModbusCommunication();


### PR DESCRIPTION
currently if a modbus request fails the logic starts over from the first input regiter fragment.
This is adds a logic that restarts at the last failed fragment. About 8-10% of all modbus requests fail due to busy conditions which the modbus library can't handle.
So retrying only the failed fragment is a big improvement.

<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

Please include a summary of the change and which issue is fixed.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [ ] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
